### PR TITLE
解决第一次打开插件手指没有滑动,而只是单击选项的时候flag值为NaN,JS报错问题

### DIFF
--- a/src/js/LArea.js
+++ b/src/js/LArea.js
@@ -168,6 +168,7 @@ window.LArea = (function() {
                     }
                 }
                 var flag = (target["new_" + target.id] - target["old_" + target.id]) / (target["n_t_" + target.id] - target["o_t_" + target.id]);
+                flag = isNaN(flag) ? 0.001 : flag;
                 if (Math.abs(flag) <= 0.2) {
                     target["spd_" + target.id] = (flag < 0 ? -0.08 : 0.08);
                 } else {


### PR DESCRIPTION
首次弹出插件的时候，手指没有滑动选项而只是单击了选项，没有触发gearTouchMove事件，导致gearTouchEnd的时候
`var flag = (target["new_" + target.id] - target["old_" + target.id]) / (target["n_t_" + target.id] - target["o_t_" + target.id]);`
flag的值为NaN，js报错，所以我在下面加了一句
`flag = isNaN(flag) ? 0.001 : flag;`
来解决这个问题，我没有改变dist文件夹的LArea.js，而只是改变了src里面的LArea.js